### PR TITLE
Isu 10 error when respondent tries to login without verifying activating account

### DIFF
--- a/oauth2server/apps/credentials/fixtures/ons_credentials.json
+++ b/oauth2server/apps/credentials/fixtures/ons_credentials.json
@@ -40,9 +40,31 @@
     "pk": 1,
     "fields": {
       "email": "testuser@email.com",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified":"True"
     }
   },
+  {
+    "model": "credentials.OAuthUser",
+    "pk": 2,
+    "fields": {
+      "email": "testuser2@email.com",
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified":"True",
+      "account_is_locked":"True"
+    }
+  },
+  {
+    "model": "credentials.OAuthUser",
+    "pk": 3,
+    "fields": {
+      "email": "testuser3@email.com",
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified":"False"
+    }
+  },
+
+
   { "model": "auth.user",
         "pk": 1,
         "fields": {

--- a/oauth2server/apps/credentials/fixtures/ons_credentials.json
+++ b/oauth2server/apps/credentials/fixtures/ons_credentials.json
@@ -5,7 +5,7 @@
     "fields": {
       "client_id": "partyService@ons.gov",
       "redirect_uri":"https://www.ons.gov.uk/",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
     }
   },
   {
@@ -14,7 +14,7 @@
     "fields": {
       "client_id": "frontstageService@ons.gov",
       "redirect_uri":"https://www.ons.gov.uk/",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
     }
   },
   {
@@ -23,7 +23,7 @@
     "fields": {
       "client_id": "ciService@ons.gov",
       "redirect_uri":"https://www.ons.gov.uk/",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
     }
   },
   {
@@ -32,7 +32,7 @@
     "fields": {
       "client_id": "ons@ons.gov",
       "redirect_uri":"https://www.ons.gov.uk/",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
     }
   },
   {
@@ -40,7 +40,7 @@
     "pk": 1,
     "fields": {
       "email": "testuser@email.com",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2",
       "account_is_verified":"True"
     }
   },
@@ -49,7 +49,7 @@
     "pk": 2,
     "fields": {
       "email": "testuser2@email.com",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2",
       "account_is_verified":"True",
       "account_is_locked":"True"
     }
@@ -59,7 +59,7 @@
     "pk": 3,
     "fields": {
       "email": "testuser3@email.com",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2",
       "account_is_verified":"False"
     }
   },
@@ -70,7 +70,7 @@
         "fields": {
             "username": "partyService@ons.gov.uk",
             "email": "partyService@ons.gov.uk",
-            "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+            "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
         }
   },
   { "model": "auth.user",
@@ -78,7 +78,7 @@
         "fields": {
             "username": "frontstageService@ons.gov.uk",
             "email": "frontstageService@ons.gov.uk",
-            "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+            "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
         }
   },
   { "model": "auth.user",
@@ -86,7 +86,7 @@
         "fields": {
             "username": "ciService@ons.gov.uk",
             "email": "ciService@ons.gov.uk",
-            "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+            "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
         }
   },
   { "model": "auth.user",
@@ -94,7 +94,7 @@
         "fields": {
             "username": "ons@ons.gov",
             "email": "ons@onsemail.gov",
-            "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+            "password": "$2a$12$aJGihWRRbi/ZDIABCJlOg.2iy9LPrF3brLIK.rSMKSMOU/g8fmTq2"
         }
   }
 

--- a/oauth2server/apps/credentials/fixtures/test_credentials.json
+++ b/oauth2server/apps/credentials/fixtures/test_credentials.json
@@ -12,7 +12,18 @@
     "pk": 1,
     "fields": {
       "email": "john@doe.com",
-      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW."
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified": "True"
+    }
+  },
+  {
+    "model": "credentials.OAuthUser",
+    "pk": 2,
+    "fields": {
+      "email": "john2@doe.com",
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified": "False"
     }
   }
+
 ]

--- a/oauth2server/apps/credentials/fixtures/test_credentials.json
+++ b/oauth2server/apps/credentials/fixtures/test_credentials.json
@@ -24,6 +24,27 @@
       "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
       "account_is_verified": "False"
     }
+  },
+  {
+    "model": "credentials.OAuthUser",
+    "pk": 3,
+    "fields": {
+      "email": "john3@doe.com",
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified": "True",
+      "account_is_locked":"True"
+    }
+  },
+  {
+    "model": "credentials.OAuthUser",
+    "pk": 4,
+    "fields": {
+      "email": "john4@doe.com",
+      "password": "$2a$12$lAfifG/wZgwdfsoR53FlU.cpjXU.1lqnI46bH/d4qOeu35fJVoFW.",
+      "account_is_verified": "True",
+      "account_is_locked":"False",
+      "failed_logins":9
+    }
   }
 
 ]

--- a/oauth2server/apps/tokens/decorators.py
+++ b/oauth2server/apps/tokens/decorators.py
@@ -31,6 +31,7 @@ from proj.exceptions import (
     ClientCredentialsRequiredException,
     InvalidClientCredentialsException,
     UserAccountLockedException,
+    UserAccountNotVerified,
     InvalidUserCredentialsException,
     AuthorizationCodeNotFoundException,
     RefreshTokenNotFoundException,
@@ -195,6 +196,10 @@ def validate_request(func):
             except OAuthUser.DoesNotExist:
                 stdlogger.warning( "Raised InvalidUserCredentialsException")
                 raise InvalidUserCredentialsException()
+
+            if not user.account_is_verified:
+                stdlogger.warning("Raised UserAccountNotVerified")
+                raise UserAccountNotVerified
 
             if user.account_locked():
                 stdlogger.warning( "Raised UserAccountLockedException")

--- a/oauth2server/apps/tokens/decorators.py
+++ b/oauth2server/apps/tokens/decorators.py
@@ -199,10 +199,10 @@ def validate_request(func):
 
             if not user.account_is_verified:
                 stdlogger.warning("Raised UserAccountNotVerified")
-                raise UserAccountNotVerified
+                raise UserAccountNotVerified()
 
             if user.account_locked():
-                stdlogger.warning( "Raised UserAccountLockedException")
+                stdlogger.warning("Raised UserAccountLockedException")
                 raise UserAccountLockedException()
 
             if not user.verify_password(password):

--- a/oauth2server/apps/tokens/tests/test_refresh_token.py
+++ b/oauth2server/apps/tokens/tests/test_refresh_token.py
@@ -134,14 +134,6 @@ class RefreshTokenTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         refreshed_access_token = OAuthAccessToken.objects.get(access_token = response.data['access_token'])
-        print "********** Refresh access token is: {}".format(refreshed_access_token)
-        print "********** Refresh access token (access token) is: {}".format(refreshed_access_token.access_token)
-        print "********** Refresh access token (refresh token) is: {}".format(refreshed_access_token.refresh_token)
-        print "********** Refresh access token (scopes) is: {}".format(refreshed_access_token.scopes)
-        print "********** Refresh access token (client) is: {}".format(refreshed_access_token.client)
-        print "********** Refresh access token (user) is: {}".format(refreshed_access_token.user)
-        print "********** Refresh access token (user email) is: {}".format(refreshed_access_token.user.email)
-
         self.assertNotEqual(refreshed_access_token.access_token, user_access_token.access_token)
         self.assertEqual(refreshed_access_token.client.client_id, 'testclient')
         self.assertEqual(refreshed_access_token.user.email, 'john@doe.com')

--- a/oauth2server/apps/tokens/tests/test_user_credentials.py
+++ b/oauth2server/apps/tokens/tests/test_user_credentials.py
@@ -87,6 +87,31 @@ class UserCredentialsTest(TestCase):
         self.assertEqual(response.data['detail'], u'Invalid client credentials')
         #self.assertEqual(response.data['error_description'], u'Invalid client credentials')
 
+
+    # This uses the john2@doe.com account to test a user who has not had his account verified.
+    def test_account_not_verifieds(self):
+        self.assertEqual(OAuthAccessToken.objects.count(), 0)
+        self.assertEqual(OAuthRefreshToken.objects.count(), 0)
+
+        response = self.api_client.post(
+            path='/api/v1/tokens/',
+            data={
+                'grant_type': 'password',
+                'username': 'john2@doe.com',
+                'password': 'testpassword',
+            },
+            HTTP_AUTHORIZATION='Basic:{}'.format(
+                base64.encodestring('testclient:testpassword')),
+        )
+
+        self.assertEqual(OAuthAccessToken.objects.count(), 0)
+        self.assertEqual(OAuthRefreshToken.objects.count(), 0)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data['detail'], u'User account not verified')
+        #print "****** response value is: {} *******".format(response.data)
+
+
     def test_success(self):
         self.assertEqual(OAuthAccessToken.objects.count(), 0)
         self.assertEqual(OAuthRefreshToken.objects.count(), 0)

--- a/oauth2server/apps/tokens/tests/test_user_credentials.py
+++ b/oauth2server/apps/tokens/tests/test_user_credentials.py
@@ -109,7 +109,6 @@ class UserCredentialsTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data['detail'], u'User account not verified')
-        #print "****** response value is: {} *******".format(response.data)
 
 
     # This uses the john3@doe.com account to test a user who has a verified account but is locked.
@@ -133,7 +132,7 @@ class UserCredentialsTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data['detail'], u'User account locked')
-        #print "****** response value is: {} *******".format(response.data)
+
 
 
 
@@ -161,7 +160,7 @@ class UserCredentialsTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data['detail'], u'User account locked')
-        #print "****** response value is: {} *******".format(response.data)
+
 
         # Now use the correct password. This should still fail with user account locked.
         response = self.api_client.post(
@@ -180,7 +179,7 @@ class UserCredentialsTest(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data['detail'], u'User account locked')
-        #print "****** response value is: {} *******".format(response.data)
+
 
 
     def test_success(self):

--- a/oauth2server/proj/exceptions.py
+++ b/oauth2server/proj/exceptions.py
@@ -23,6 +23,14 @@ class UserAccountLockedException(APIException):
     default_detail = _(u'User account locked')
 
 
+class UserAccountNotVerified(APIException):
+    status_code = status.HTTP_401_UNAUTHORIZED
+    default_error = u'account_not_verified'
+    default_detail = _(u'User account not verified')
+
+
+
+
 class InvalidUserCredentialsException(APIException):
     status_code = status.HTTP_401_UNAUTHORIZED
     default_error = u'unauthorized_user'

--- a/oauth2server/proj/settings/local.example.py
+++ b/oauth2server/proj/settings/local.example.py
@@ -26,3 +26,7 @@ OAUTH2_SERVER = {
     'REFRESH_TOKEN_LIFETIME': 3600,
     'IGNORE_CLIENT_REQUESTED_SCOPE': False,
 }
+
+# This defined the max number of failed logins a user can have before the account is locked
+MAX_FAILED_LOGINS = 10
+


### PR DESCRIPTION
This puts in the logic to have the OAuth2 server reject a request for a token if the account is not verified. There are also a number of new test cases added to test boundary conditions on accounts not being verified to not verified as well combinations of accounts being locked. 