### PR TITLE
[69] Fixing email case sensitivity during login

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ python:
   - "2.7"
 env:
   - DJANGO=1.9 DB=postgres
-branches:
-  only:
-    - develop
-    - master
 cache:
   directories:
     - ~/virtualenv/python2.7/

--- a/oauth2server/apps/tokens/decorators.py
+++ b/oauth2server/apps/tokens/decorators.py
@@ -192,12 +192,11 @@ def validate_request(func):
 
             stdlogger.debug("Grant_type password. Second function")
 
-            try:
-                user = OAuthUser.objects.get(email=username)
-            except OAuthUser.DoesNotExist:
+            users = OAuthUser.objects.filter(email__iexact=username)
+            if not users.exists():
                 stdlogger.warning( "Raised InvalidUserCredentialsException")
                 raise InvalidUserCredentialsException()
-
+            user = users[0]
             if not user.verify_password(password):
                 stdlogger.debug("I've raised InvalidUserCredentialsException - password failed the check!")
                 user.increment_failed_logins()


### PR DESCRIPTION
Case insensitive search when looking for email for user login. This
will allow users to put their email in any case and still login.

apps.tokens.tests.test_user_credentials.
UserCredentialsTest#test_should_login_with_different_case_email
demonstrates a call to the auth token api with an email address with
a different case to the email address stored.